### PR TITLE
[DOC] new line sentences -- numbers in md

### DIFF
--- a/docs/guard-functions.md
+++ b/docs/guard-functions.md
@@ -1,6 +1,7 @@
 # Guard functions
 
-Guard functions are the middleware between navigation and rendering. They can contain complex, asynchronous logic in order to fetch data for a route.
+Guard functions are the middleware between navigation and rendering.
+They can contain complex, asynchronous logic in order to fetch data for a route.
 
 - [API](#api)
 - [`next` functions](#next-functions)
@@ -52,7 +53,8 @@ While we use `to` and `from` to get context of our navigation history, we use `n
 
   _**Note:** Redirecting to a different location will still run the guards of the new location before rendering it._
 
-You can call any of the `next` functions at any time in your guard function. This will immediately stop execution of the current guard and move onto the next one.
+You can call any of the `next` functions at any time in your guard function.
+This will immediately stop execution of the current guard and move onto the next one.
 
 ## Error handling
 
@@ -62,7 +64,8 @@ This can be accomplished by throwing an `Error`.
 
 Much like the `next` function, you can throw an `Error` at any time in your guard function, and it will immediately stop execution of the current guard.
 
-However, instead of moving to the next guard, it will cancel all guards in the queue. Then, the [error page](docs/page-components.md) (as set by a [`GuardProvider`](/docs/guard-provider.md) or [`GuardedRoute`](/docs/guarded-route.md)) will display.
+However, instead of moving to the next guard, it will cancel all guards in the queue.
+Then, the [error page](docs/page-components.md) (as set by a [`GuardProvider`](/docs/guard-provider.md) or [`GuardedRoute`](/docs/guarded-route.md)) will display.
 
 ## Example
 
@@ -96,7 +99,8 @@ All guard functions accept the same three arguments:
 
 - `next`: a multi-use function for advancing to the next guard function
 
-Guard functions don't advance until the `next` function is called. This allows the logic inside of them to be asynchronous, hence the `async` keyword.
+Guard functions don't advance until the `next` function is called.
+This allows the logic inside of them to be asynchronous, hence the `async` keyword.
 
 ---
 
@@ -106,7 +110,8 @@ const { name } = to.match.params;
 
 In this line, we are destructuring the `to` route's match params to get the name of the pokemon.
 
-The `to` and `from` arguments allow us to use the same props that the `Router` passes to the page component. These include the following:
+The `to` and `from` arguments allow us to use the same props that the `Router` passes to the page component.
+These include the following:
 
 - [`history`](https://reacttraining.com/react-router/core/api/history)
 
@@ -122,7 +127,8 @@ The `to` and `from` arguments allow us to use the same props that the `Router` p
     next.props({ pokemon });
 ```
 
-In these lines, we are calling an API function in order to get a pokemon with the route's name. Then, we are using one of `next`'s three functionalities to pass the pokemon as a prop to the route.
+In these lines, we are calling an API function in order to get a pokemon with the route's name.
+Then, we are using one of `next`'s three functionalities to pass the pokemon as a prop to the route.
 
 For more information on the next function, check out the [`next` functions section](#next-functions).
 

--- a/docs/guarded-route.md
+++ b/docs/guarded-route.md
@@ -52,6 +52,6 @@ const App = () => (
 
 In order to provide more information about a route, we've added a `meta` prop to the `GuardedRoute`.
 
-The `meta` object can include anything! In our [basic demo](/demos/basic/src/router/routes.js), we used the `meta` object to determine which pages required auth.
+The `meta` object can include anything! In our [basic demo](/demos/basic/src/router/routes.js) we used the `meta` object to determine which pages required auth.
 
 You can access a route's metadata using `to.meta` in a guard function.

--- a/docs/navigation-lifecycle.md
+++ b/docs/navigation-lifecycle.md
@@ -8,15 +8,15 @@ With the addition of guard middleware, the navigation lifecycle has changed. It 
 
 1. Start on _Page A_.
 
-2. Navigation initiated. _The loading page is shown._
+1. Navigation initiated. _The loading page is shown._
 
-3. Check if there are guards are left in the queue.
+1. Check if there are guards left in the queue.
 
    - If there are guards, continue to step 4.
 
    - If no guards remain, skip to step 5.
 
-4. Run the top guard in the queue:
+1. Run the top guard in the queue:
 
    - `next()`: Return to step 3.
 
@@ -26,4 +26,4 @@ With the addition of guard middleware, the navigation lifecycle has changed. It 
 
    - `Error`: Navigation has been prevented. _The error page is shown._
 
-5. Navigation was successful! _Page B is shown._
+1. Navigation was successful! _Page B is shown._


### PR DESCRIPTION
# Description

Slight update on some documentation.

## What this does

Updates some of the documentation.
Markdown will include new-lined sentences in the same paragraph (only 2 line breaks adds a line break when being viewed).  This can make it easier for other contributors to read through documentation and contribute since the diff's in GitHub will be a bit more readable.

Also, for markdown, when numbering a list, you can have all the numbers as `1` and the reader will automatically number them for you.  This can be handy if you ever decide to add additional items (you won't have to renumber).

## How to test

No tests!
