### PR TITLE
Unit Tests: Components

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -823,6 +823,15 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -3641,6 +3650,20 @@
         }
       }
     },
+    "history": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^0.4.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -5950,6 +5973,12 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -6750,6 +6779,12 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
       "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
     },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "dev": true
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -7069,6 +7104,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",

--- a/package/package.json
+++ b/package/package.json
@@ -56,6 +56,7 @@
     "babel-plugin-dev-expression": "^0.2.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
+    "history": "^4.9.0",
     "jest": "^24.8.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/package/src/ContextWrapper.tsx
+++ b/package/src/ContextWrapper.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 
 interface Props<T> {
   context: React.Context<T>;
-  value: T;
+  value?: T;
 }
 
 function ContextWrapper<T>({ children, context, value }: React.PropsWithChildren<Props<T>>) {

--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -4,25 +4,8 @@ import { matchPath, Redirect, Route } from 'react-router-dom';
 import { ErrorPageContext, FromRouteContext, GuardContext, LoadingPageContext } from './contexts';
 import { usePrevious, useStateRef, useStateWhenMounted } from './hooks';
 import renderPage from './renderPage';
-import {
-  GuardFunction,
-  GuardProps,
-  GuardType,
-  GuardTypes,
-  Next,
-  NextAction,
-  NextPropsPayload,
-  NextRedirectPayload,
-} from './types';
-
-type PageProps = NextPropsPayload;
-type RouteError = string | Record<string, any> | null;
-type RouteRedirect = NextRedirectPayload | null;
-
-interface GuardsResolve {
-  props: PageProps;
-  redirect: RouteRedirect;
-}
+import validateGuardsForRoute from './validateGuardsForRoute';
+import { GuardProps, GuardToRoute, PageProps, RouteError, RouteRedirect } from './types';
 
 const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta, render }) => {
   const routeProps = useContext(RouterContext);
@@ -54,93 +37,22 @@ const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta,
   ]);
 
   /**
-   * Memoized callback to get the next callback function used in guards.
-   * Assigns the `props` and `redirect` functions to callback.
-   */
-  const getNextFn = useCallback((resolve: Function): Next => {
-    const getResolveFn = (type: GuardType) => (payload: NextPropsPayload | NextRedirectPayload) =>
-      resolve({ type, payload });
-
-    const next = () => resolve({ type: GuardTypes.CONTINUE });
-
-    return Object.assign(next, {
-      props: getResolveFn(GuardTypes.PROPS),
-      redirect: getResolveFn(GuardTypes.REDIRECT),
-    });
-  }, []);
-
-  /**
-   * Runs through a single guard, passing it the current route's props,
-   * the previous route's props, and the next callback function. If an
-   * error occurs, it will be thrown by the Promise.
-   *
-   * @param guard the guard function
-   * @returns a Promise returning the guard payload
-   */
-  const runGuard = (guard: GuardFunction): Promise<NextAction> =>
-    new Promise(async (resolve, reject) => {
-      try {
-        const to = {
-          ...routeProps,
-          meta: meta || {},
-        };
-        await guard(to, fromRouteProps, getNextFn(resolve));
-      } catch (error) {
-        reject(error);
-      }
-    });
-
-  /**
-   * Loops through all guards in context. If the guard adds new props
-   * to the page or causes a redirect, these are tracked in the state
-   * constants defined above.
-   */
-  const resolveAllGuards = async (): Promise<GuardsResolve> => {
-    let index = 0;
-    let props = {};
-    let redirect = null;
-    if (guards) {
-      while (!redirect && index < guards.length) {
-        const { type, payload } = await runGuard(guards[index]);
-        if (payload) {
-          if (type === GuardTypes.REDIRECT) {
-            redirect = payload;
-          } else if (type === GuardTypes.PROPS) {
-            props = Object.assign(props, payload);
-          }
-        }
-        index += 1;
-      }
-    }
-    return {
-      props,
-      redirect,
-    };
-  };
-
-  /**
    * Validates the route using the guards. If an error occurs, it
    * will toggle the route error state.
    */
   const validateRoute = async (): Promise<void> => {
     const currentRequests = validationsRequested.current;
 
-    let pageProps: PageProps = {};
-    let routeError: RouteError = null;
-    let routeRedirect: RouteRedirect = null;
-
-    try {
-      const { props, redirect } = await resolveAllGuards();
-      pageProps = props;
-      routeRedirect = redirect;
-    } catch (error) {
-      routeError = error.message || 'Not found.';
-    }
+    const to: GuardToRoute = {
+      ...routeProps,
+      meta: meta || {},
+    };
+    const { error, props, redirect } = await validateGuardsForRoute(guards, to, fromRouteProps);
 
     if (currentRequests === getValidationsRequested()) {
-      setPageProps(pageProps);
-      setRouteError(routeError);
-      setRouteRedirect(routeRedirect);
+      setPageProps(props);
+      setRouteError(error);
+      setRouteRedirect(redirect);
       setRouteValidated(true);
     }
   };

--- a/package/src/__tests__/ContextWrapper.test.tsx
+++ b/package/src/__tests__/ContextWrapper.test.tsx
@@ -1,0 +1,86 @@
+import React, { useContext } from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import ContextWrapper from '../ContextWrapper';
+import { ErrorPageContext, LoadingPageContext } from '../contexts';
+
+interface ContextConsumerProps<T> {
+  context: React.Context<T>;
+}
+function ContextConsumer<T>({ context }: React.PropsWithChildren<ContextConsumerProps<T>>) {
+  const value = useContext(context);
+  return <div data-value={value} />;
+}
+
+function getCtxValue<T>(wrapper: ReactWrapper): T {
+  return wrapper.find('div').prop('data-value');
+}
+
+describe('ContextWrapper', () => {
+  let wrapper: ReactWrapper | null = null;
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    wrapper = null;
+  });
+
+  it('should render', () => {
+    wrapper = mount(<ContextWrapper context={ErrorPageContext} />);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('should render children', () => {
+    wrapper = mount(
+      <ContextWrapper context={ErrorPageContext}>
+        <div />
+      </ContextWrapper>,
+    );
+    expect(wrapper.find('div').exists()).toBeTruthy();
+  });
+
+  it('should render a context provider if a value is provided', () => {
+    const VALUE = 'hello';
+    wrapper = mount(
+      <ContextWrapper context={ErrorPageContext} value={VALUE}>
+        <ContextConsumer context={ErrorPageContext} />
+      </ContextWrapper>,
+    );
+    expect(getCtxValue(wrapper)).toEqual(VALUE);
+  });
+
+  it('should render a fragment if no value is provided', () => {
+    wrapper = mount(
+      <ContextWrapper context={ErrorPageContext}>
+        <ContextConsumer context={ErrorPageContext} />
+      </ContextWrapper>,
+    );
+    expect(getCtxValue(wrapper)).toEqual(null);
+  });
+
+  it('should only provide the value of the innermost context wrapper', () => {
+    const OUTER_VALUE = 'hello';
+    const INNER_VALUE = 'world';
+    wrapper = mount(
+      <ContextWrapper context={ErrorPageContext} value={OUTER_VALUE}>
+        <ContextWrapper context={ErrorPageContext} value={INNER_VALUE}>
+          <ContextConsumer context={ErrorPageContext} />
+        </ContextWrapper>
+      </ContextWrapper>,
+    );
+    expect(getCtxValue(wrapper)).toEqual(INNER_VALUE);
+  });
+
+  it(`should not override a parent context wrapper's value if different context types are provided`, () => {
+    const ERROR_VALUE = 'hello';
+    const LOADING_VALUE = 'world';
+    wrapper = mount(
+      <ContextWrapper context={ErrorPageContext} value={ERROR_VALUE}>
+        <ContextWrapper context={LoadingPageContext} value={LOADING_VALUE}>
+          <ContextConsumer context={ErrorPageContext} />
+        </ContextWrapper>
+      </ContextWrapper>,
+    );
+    expect(getCtxValue(wrapper)).toEqual(ERROR_VALUE);
+  });
+});

--- a/package/src/__tests__/validateGuardsForRoute.test.tsx
+++ b/package/src/__tests__/validateGuardsForRoute.test.tsx
@@ -1,0 +1,117 @@
+import { createBrowserHistory } from 'history';
+import { getNextFn, runGuard } from '../validateGuardsForRoute';
+import { GuardTypes } from '../types';
+
+describe('validateGuardsForRoute', () => {
+  const FROM_ROUTE_PROPS = {
+    history: createBrowserHistory(),
+    match: {
+      params: {},
+      isExact: true,
+      path: '',
+      url: '/',
+    },
+    location: {
+      hash: 'k12dr',
+      pathname: '/',
+      search: '',
+      state: {},
+    },
+  };
+  const TO_ROUTE_PROPS = {
+    ...FROM_ROUTE_PROPS,
+    meta: {},
+  };
+
+  describe('getNextFn', () => {
+    let value: any;
+    let callback: jest.Mock;
+
+    beforeEach(() => {
+      value = null;
+      callback = jest.fn(obj => {
+        value = obj;
+      });
+    });
+
+    it('should return a function', () => {
+      const next = getNextFn(() => null);
+      expect(typeof next).toEqual('function');
+    });
+
+    it('should have properties "props" and "redirect" that are also functions', () => {
+      const next = getNextFn(() => null);
+      expect(typeof next.props).toEqual('function');
+      expect(typeof next.redirect).toEqual('function');
+    });
+
+    it('when calling next(), should call the given callback function with the continue type', () => {
+      const next = getNextFn(callback);
+      next();
+      expect(callback.mock.calls.length).toEqual(1);
+      expect(value).toEqual({ type: GuardTypes.CONTINUE });
+    });
+
+    it('when calling next.props(), should call the given callback function with the props type and the passed arg as payload', () => {
+      const PROPS = { hello: 'world' };
+      const next = getNextFn(callback);
+      next.props(PROPS);
+      expect(callback.mock.calls.length).toEqual(1);
+      expect(value).toEqual({ type: GuardTypes.PROPS, payload: PROPS });
+    });
+
+    it('when calling next.redirect(), should call the given callback function with the redirect type and the passed arg as payload', () => {
+      const REDIRECT = '/ok';
+      const next = getNextFn(callback);
+      next.redirect(REDIRECT);
+      expect(callback.mock.calls.length).toEqual(1);
+      expect(value).toEqual({ type: GuardTypes.REDIRECT, payload: REDIRECT });
+
+      const OBJ_REDIRECT = { pathname: '/ok', search: '?hello=world' };
+      next.redirect(OBJ_REDIRECT);
+      expect(callback.mock.calls.length).toEqual(2);
+      expect(value).toEqual({ type: GuardTypes.REDIRECT, payload: OBJ_REDIRECT });
+    });
+  });
+
+  describe('runGuard', () => {
+    let guard: jest.Mock;
+
+    beforeEach(() => {
+      guard = jest.fn((to, from, next) => next());
+    });
+
+    it('should return a promise', () => {
+      const promise = runGuard(guard, TO_ROUTE_PROPS, FROM_ROUTE_PROPS);
+      expect(promise).toHaveProperty('then');
+      // eslint-disable-next-line promise/prefer-await-to-then
+      expect(typeof promise.then).toEqual('function');
+    });
+
+    it('should call the passed guard', async () => {
+      await runGuard(guard, TO_ROUTE_PROPS, FROM_ROUTE_PROPS);
+      expect(guard.mock.calls.length).toEqual(1);
+    });
+
+    it('should reject promise on guard failure', async () => {
+      const ERR_MSG = 'Route not found';
+      guard = jest.fn(() => {
+        throw new Error(ERR_MSG);
+      });
+
+      let value = 'ok';
+      try {
+        await runGuard(guard, TO_ROUTE_PROPS, FROM_ROUTE_PROPS);
+      } catch (error) {
+        value = error.message;
+      }
+      expect(value).toEqual(ERR_MSG);
+    });
+
+    it('should return guard payload object on guard success', async () => {
+      const value = await runGuard(guard, TO_ROUTE_PROPS, FROM_ROUTE_PROPS);
+      expect(typeof value).toEqual('object');
+      expect(value).toEqual({ type: GuardTypes.CONTINUE });
+    });
+  });
+});

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -62,6 +62,10 @@ export type GuardFunction = (
  */
 export type PageComponent = ComponentType | null | undefined | string | boolean | number;
 
+export type PageProps = NextPropsPayload;
+export type RouteError = string | Record<string, any> | null;
+export type RouteRedirect = NextRedirectPayload | null;
+
 /**
  * Props
  */

--- a/package/src/validateGuardsForRoute.ts
+++ b/package/src/validateGuardsForRoute.ts
@@ -1,0 +1,119 @@
+import {
+  GuardFunction,
+  GuardTypes,
+  Next,
+  NextAction,
+  NextPropsPayload,
+  NextRedirectPayload,
+  GuardToRoute,
+  GuardFunctionRouteProps,
+  PageProps,
+  RouteError,
+  RouteRedirect,
+} from './types';
+
+interface GuardsResolve {
+  props: PageProps;
+  redirect: RouteRedirect;
+}
+
+interface Validation {
+  error: RouteError;
+  props: PageProps;
+  redirect: RouteRedirect;
+}
+
+/**
+ * Memoized callback to get the next callback function used in guards.
+ * Assigns the `props` and `redirect` functions to callback.
+ */
+export const getNextFn = (resolve: Function): Next => {
+  const next = () => resolve({ type: GuardTypes.CONTINUE });
+  return Object.assign(next, {
+    props: (payload: NextPropsPayload) => resolve({ type: GuardTypes.PROPS, payload }),
+    redirect: (payload: NextRedirectPayload) => resolve({ type: GuardTypes.REDIRECT, payload }),
+  });
+};
+
+/**
+ * Runs through a single guard, passing it the current route's props,
+ * the previous route's props, and the next callback function. If an
+ * error occurs, it will be thrown by the Promise.
+ *
+ * @param guard the guard function
+ * @returns a Promise returning the guard payload
+ */
+export const runGuard = (
+  guard: GuardFunction,
+  to: GuardToRoute,
+  from: GuardFunctionRouteProps | null,
+): Promise<NextAction> =>
+  new Promise(async (resolve, reject) => {
+    try {
+      await guard(to, from, getNextFn(resolve));
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+/**
+ * Loops through all guards in context. If the guard adds new props
+ * to the page or causes a redirect, these are tracked in the state
+ * constants defined above.
+ */
+export const resolveAllGuards = async (
+  guards: GuardFunction[] | null,
+  to: GuardToRoute,
+  from: GuardFunctionRouteProps | null,
+): Promise<GuardsResolve> => {
+  let index = 0;
+  let props = {};
+  let redirect = null;
+  if (guards) {
+    while (!redirect && index < guards.length) {
+      const { type, payload } = await runGuard(guards[index], to, from);
+      if (payload) {
+        if (type === GuardTypes.REDIRECT) {
+          redirect = payload;
+        } else if (type === GuardTypes.PROPS) {
+          props = Object.assign(props, payload);
+        }
+      }
+      index += 1;
+    }
+  }
+  return {
+    props,
+    redirect,
+  };
+};
+
+/**
+ * Validates the route using the guards. If an error occurs, it
+ * will toggle the route error state.
+ */
+const validateGuardsForRoute = async (
+  guards: GuardFunction[] | null,
+  to: GuardToRoute,
+  from: GuardFunctionRouteProps | null,
+): Promise<Validation> => {
+  let pageProps: PageProps = {};
+  let routeError: RouteError = null;
+  let routeRedirect: RouteRedirect = null;
+
+  try {
+    const { props, redirect } = await resolveAllGuards(guards, to, from);
+    pageProps = props;
+    routeRedirect = redirect;
+  } catch (error) {
+    routeError = error.message || 'Not found.';
+  }
+
+  return {
+    error: routeError,
+    props: pageProps,
+    redirect: routeRedirect,
+  };
+};
+
+export default validateGuardsForRoute;


### PR DESCRIPTION
# Description

Adds unit tests for components

## What this does

1. Refactors `Guard` component to separate validation logic into `validateGuardsForRoute` helper function
2. Adds tests for `ContextWrapper`
3. Adds tests for `validateGuardsForRoute`
4. Adds tests for `renderPage`

## Left to do

- [ ] Add tests for `Guard`
- [ ] Add tests for `GuardedRoute`
- [ ] Add tests for `GuardProvider`

## How to test

1. `npm test`
