### PR TITLE
Bug: Fixes `Page Not Found` error on Netlify demo site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   base = "."
   publish = "demos/intermediate/dist"
   command = "npm run bootstrap && npm run build:demo"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
# Description

Addresses `Page Not Found` error on Netlify demo site

## What this does

1. Adds `[[redirects]]` to `netlify.toml` to redirect all requests to the `index.html` file

## How to test

1. Visit the Netlify deploy preview site
2. Click on any Pokémon from the index page, and wait for the page to load
3. Refresh the page. The page should appear (instead of Netlify's `Page Not Found` error
