### PR TITLE
Make hasPathChanged on the Guard component configurable

### DIFF
--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -24,13 +24,22 @@ interface GuardsResolve {
   redirect: RouteRedirect;
 }
 
-const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta, render }) => {
+const Guard: React.FunctionComponent<GuardProps> = ({
+  children,
+  component,
+  meta,
+  render,
+  pathChanged,
+  name,
+}) => {
   const routeProps = useContext(RouterContext);
   const routePrevProps = usePrevious(routeProps);
-  const hasPathChanged = useMemo(
-    () => routeProps.location.pathname !== routePrevProps.location.pathname,
-    [routePrevProps, routeProps],
-  );
+  const hasPathChanged = useMemo(() => {
+    if (pathChanged && typeof pathChanged === 'function') {
+      return pathChanged(routePrevProps, routeProps, name);
+    }
+    return routeProps.location.pathname !== routePrevProps.location.pathname;
+  }, [routePrevProps, routeProps]);
   const fromRouteProps = useContext(FromRouteContext);
 
   const guards = useContext(GuardContext);

--- a/package/src/GuardedRoute.tsx
+++ b/package/src/GuardedRoute.tsx
@@ -15,6 +15,7 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
   ignoreGlobal,
   loading,
   meta,
+  pathChanged,
   render,
   path,
   ...routeProps
@@ -32,7 +33,12 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
         <GuardContext.Provider value={routeGuards}>
           <ContextWrapper<PageComponent> context={LoadingPageContext} value={loading}>
             <ContextWrapper<PageComponent> context={ErrorPageContext} value={error}>
-              <Guard name={path} component={component} meta={meta} render={render}>
+              <Guard
+                name={path}
+                pathChanged={pathChanged}
+                component={component}
+                meta={meta}
+                render={render}>
                 {children}
               </Guard>
             </ContextWrapper>

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -74,6 +74,11 @@ export interface BaseGuardProps {
 
 export type PropsWithMeta<T> = T & {
   meta?: Meta;
+  pathChanged?: (
+    routePrevProps: RouteComponentProps,
+    routeProps: RouteComponentProps,
+    path?: string | string[],
+  ) => boolean;
 };
 
 export type GuardProviderProps = BaseGuardProps;


### PR DESCRIPTION
# Description

The parent route will rerender (destroy and initialize) each time the user navigates between child routes.
This can cause issues when fetching data inside a container/parent component or when the parent component must hold some state because the component will lose his current state each time the user navigates between the child routes.
 
Therefore I thought it will be a good idea to make the `hasPathChanged` function configurable so the developer can choose when the guards of the parent should be called.

Example:
Navigate to /users => check user guards
Navigate from /users to /users/123 => don't check the /user guards (don't destroy the /users route)
Navigate from /users/123 to /users/overview  => don't check the /user guards (don't destroy the /users route)

## What this does

It will allow the developer to set his own `hasPathChanged` function. 

```typescript
const isPathChanged = (
    routePrevProps: RouteComponentProps,
    routeProps: RouteComponentProps,
    path?: string | string[]): boolean =>  {
    // custome isPathChanged function
    return true;
}

<GuardedRoute
    path={route.path}
    pathChanged={isPathChanged}
    component={UsersComponent}/>

```
