### PR TITLE
Feature: Add `rawError` option

### DIFF
--- a/docs/page-components.md
+++ b/docs/page-components.md
@@ -41,6 +41,18 @@ Typically, error pages will be the same component as a Not Found or 404 page.
 
 _**Note:** If using a React component for your error page, it can receive the error message thrown by a guard function via an `error` prop._
 
+## Raw errors
+
+By default, only the `message` property of the error thrown by a guard is sent to the Error page (or if no `message` property is available, the string `"Not found."`).
+
+If you want the exact value thrown by your guards available on the `error` prop for your Error page you can set the `rawError` prop to `true`.
+
+It can be set either:
+
+- _globally_ as the `rawError` prop of a [`GuardProvider`](/docs/guard-provider.md)
+
+- _individually_ as the `rawError` prop of a [`GuardedRoute`](/docs/guarded-route.md)
+
 ## Examples
 
 With strings:

--- a/package/src/GuardProvider.tsx
+++ b/package/src/GuardProvider.tsx
@@ -1,7 +1,13 @@
 import React, { useContext } from 'react';
 import { __RouterContext as RouterContext } from 'react-router';
 import invariant from 'tiny-invariant';
-import { ErrorPageContext, FromRouteContext, GuardContext, LoadingPageContext } from './contexts';
+import {
+  ErrorPageContext,
+  FromRouteContext,
+  GuardContext,
+  LoadingPageContext,
+  RawErrorContext,
+} from './contexts';
 import { useGlobalGuards, usePrevious } from './hooks';
 import { GuardProviderProps } from './types';
 
@@ -11,6 +17,7 @@ const GuardProvider: React.FunctionComponent<GuardProviderProps> = ({
   ignoreGlobal,
   loading,
   error,
+  rawError,
 }) => {
   const routerContext = useContext(RouterContext);
   invariant(!!routerContext, 'You should not use <GuardProvider> outside a <Router>');
@@ -20,12 +27,15 @@ const GuardProvider: React.FunctionComponent<GuardProviderProps> = ({
 
   const loadingPage = useContext(LoadingPageContext);
   const errorPage = useContext(ErrorPageContext);
+  const useRawErrors = useContext(RawErrorContext);
 
   return (
     <GuardContext.Provider value={providerGuards}>
       <LoadingPageContext.Provider value={loading || loadingPage}>
         <ErrorPageContext.Provider value={error || errorPage}>
-          <FromRouteContext.Provider value={from}>{children}</FromRouteContext.Provider>
+          <RawErrorContext.Provider value={rawError || useRawErrors}>
+            <FromRouteContext.Provider value={from}>{children}</FromRouteContext.Provider>
+          </RawErrorContext.Provider>
         </ErrorPageContext.Provider>
       </LoadingPageContext.Provider>
     </GuardContext.Provider>

--- a/package/src/GuardedRoute.tsx
+++ b/package/src/GuardedRoute.tsx
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom';
 import invariant from 'tiny-invariant';
 import ContextWrapper from './ContextWrapper';
 import Guard from './Guard';
-import { ErrorPageContext, GuardContext, LoadingPageContext } from './contexts';
+import { ErrorPageContext, GuardContext, LoadingPageContext, RawErrorContext } from './contexts';
 import { useGlobalGuards } from './hooks';
 import { GuardedRouteProps, PageComponent } from './types';
 
@@ -11,6 +11,7 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
   children,
   component,
   error,
+  rawError,
   guards,
   ignoreGlobal,
   loading,
@@ -32,9 +33,13 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
         <GuardContext.Provider value={routeGuards}>
           <ContextWrapper<PageComponent> context={LoadingPageContext} value={loading}>
             <ContextWrapper<PageComponent> context={ErrorPageContext} value={error}>
-              <Guard name={path} component={component} meta={meta} render={render}>
-                {children}
-              </Guard>
+              <ContextWrapper<boolean | null | undefined>
+                context={RawErrorContext}
+                value={rawError}>
+                <Guard name={path} component={component} meta={meta} render={render}>
+                  {children}
+                </Guard>
+              </ContextWrapper>
             </ContextWrapper>
           </ContextWrapper>
         </GuardContext.Provider>

--- a/package/src/contexts.ts
+++ b/package/src/contexts.ts
@@ -9,3 +9,5 @@ export const FromRouteContext = createContext<RouteComponentProps | null>(null);
 export const GuardContext = createContext<GuardFunction[] | null>(null);
 
 export const LoadingPageContext = createContext<PageComponent>(null);
+
+export const RawErrorContext = createContext<boolean | null | undefined>(false);

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -70,6 +70,7 @@ export interface BaseGuardProps {
   ignoreGlobal?: boolean;
   loading?: PageComponent;
   error?: PageComponent;
+  rawError?: boolean;
 }
 
 export type PropsWithMeta<T> = T & {


### PR DESCRIPTION
# Description

Introduces a new boolean option `rawError` to [`GuardProvider`](/docs/guard-provider.md) and [`GuardedRoute`](/docs/guarded-route.md) which makes them pass through errors thrown by [`GuardFunctions`](/docs/guard-functions.md) unaltered.

## What this does

It alters the behaviour of error handling as seen [here](https://github.com/Upstatement/react-router-guards/compare/master...rafoss:feature/add-option-rawError?expand=1#diff-0cbf9339c2ee0a4254953295459b03a0R144) to use the raw thrown value instead of trying to access the `message` property on it and returning `"Not found."` as a fallback.

## Use case

Custom errors such as extended Error objects which specify further details or entirely custom types thrown by [`GuardFunctions`](/docs/guard-functions.md) can now be accessed on the `error` prop of the Error page component.
A [`GuardFunction`](/docs/guard-functions.md) could for instance `throw 403;` to indicate HTTP status code `403 Forbidden` to the Error page so it can conditionally render a forbidden page. This way it's not necessary to supply different `error` props per [`GuardedRoute`](/docs/guarded-route.md) you want to display different errors for.

## Sidenote

In my opinion, a breaking change to supply the raw error by default would be nicer, but may cause more problems than it solves, so I've submitted this PR as a backwards compatible solution.

## How to test

No test changes were made.
