### PR TITLE
Expose new `LoadingPageComponentType` and `ErrorPageComponentType` types

### DIFF
--- a/demos/intermediate/package-lock.json
+++ b/demos/intermediate/package-lock.json
@@ -5674,14 +5674,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "react-router-guards": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-router-guards/-/react-router-guards-1.0.2.tgz",
-      "integrity": "sha512-RuNR+1sa7M96Jc3/hQxYw1E1ItYRUGFn+MKSoHSYCoWm6/JneA0z7C5spC9211FlkVXm79nonNtGy7exHSyKbA==",
-      "requires": {
-        "tiny-invariant": "^1.0.4"
-      }
-    },
     "react-waypoint": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-9.0.2.tgz",

--- a/demos/intermediate/src/containers/Loading/index.tsx
+++ b/demos/intermediate/src/containers/Loading/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Pokeball } from 'svgs';
 import styles from './loading.module.scss';
+import { LoadingPageComponentType } from 'react-router-guards';
 
-const Loading = () => (
+const Loading: LoadingPageComponentType = () => (
   <div className={styles.container}>
     <div className={styles.icon}>
       <Pokeball isAnimated />

--- a/demos/intermediate/src/containers/Loading/index.tsx
+++ b/demos/intermediate/src/containers/Loading/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { LoadingPageComponentType } from 'react-router-guards';
 import { Pokeball } from 'svgs';
 import styles from './loading.module.scss';
-import { LoadingPageComponentType } from 'react-router-guards';
 
 const Loading: LoadingPageComponentType = () => (
   <div className={styles.container}>

--- a/demos/intermediate/src/containers/NotFound/index.tsx
+++ b/demos/intermediate/src/containers/NotFound/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { ErrorPageComponentType } from 'react-router-guards';
 import { Link } from 'components';
 import styles from './notFound.module.scss';
-import { ErrorPageComponentType } from 'react-router-guards';
 
 const NotFound: ErrorPageComponentType = ({ error }) => (
   <div className={styles.container}>

--- a/demos/intermediate/src/containers/NotFound/index.tsx
+++ b/demos/intermediate/src/containers/NotFound/index.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { RouteError } from 'react-router-guards';
 import { Link } from 'components';
 import styles from './notFound.module.scss';
+import { ErrorPageComponentType } from 'react-router-guards';
 
-interface NotFoundProps {
-  error: RouteError;
-}
-
-const NotFound = ({ error }: NotFoundProps) => (
+const NotFound: ErrorPageComponentType = ({ error }) => (
   <div className={styles.container}>
     <img className={styles.image} src={`/img/missingno.png`} alt="Not found" />
     <h1 className={styles.title}>Uh-oh!</h1>

--- a/demos/intermediate/src/containers/NotFound/index.tsx
+++ b/demos/intermediate/src/containers/NotFound/index.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
+import { RouteError } from 'react-router-guards';
 import { Link } from 'components';
 import styles from './notFound.module.scss';
 
-const NotFound = () => (
+interface NotFoundProps {
+  error: RouteError;
+}
+
+const NotFound = ({ error }: NotFoundProps) => (
   <div className={styles.container}>
     <img className={styles.image} src={`/img/missingno.png`} alt="Not found" />
     <h1 className={styles.title}>Uh-oh!</h1>
     <p className={styles.body}>We couldn't catch that Pokémon.</p>
+    {error && <small className={styles.error}>{error}</small>}
+
     <Link to="/">View 'em all</Link>
   </div>
 );

--- a/demos/intermediate/src/containers/NotFound/notFound.module.scss
+++ b/demos/intermediate/src/containers/NotFound/notFound.module.scss
@@ -22,8 +22,10 @@
   margin-bottom: $spacing--base;
 }
 
-.body {
+.error {
   margin-bottom: $spacing--lg;
+  margin-top: $spacing--base;
+  opacity: 0.5;
 
   @include mq($bp--mobile) {
     margin-bottom: $spacing--xl;

--- a/docs/guard-provider.md
+++ b/docs/guard-provider.md
@@ -14,8 +14,8 @@ The `GuardProvider` provides an API for declaring global guards and loading and 
 interface GuardProviderProps {
   guards?: GuardFunction[];
   ignoreGlobal?: boolean;
-  loading?: PageComponent;
-  error?: PageComponent;
+  loading?: LoadingPageComponent;
+  error?: ErrorPageComponent;
 }
 ```
 

--- a/docs/guarded-route.md
+++ b/docs/guarded-route.md
@@ -14,8 +14,8 @@ The `GuardedRoute`, on top of accepting the same props as a regular [`Route`](ht
 interface GuardedRouteProps extends RouteProps {
   guards?: GuardFunction[];
   ignoreGlobal?: boolean;
-  loading?: PageComponent;
-  error?: PageComponent;
+  loading?: LoadingPageComponent;
+  error?: ErrorPageComponent;
   meta?: Record<string, any>;
 }
 ```

--- a/docs/page-components.md
+++ b/docs/page-components.md
@@ -9,10 +9,6 @@ Page components are used for setting loading and error pages.
 
 ## API
 
-```ts
-type PageComponent = React.Component | string | boolean | number | null | undefined;
-```
-
 ## Loading page
 
 Loading pages are React components that are displayed while guard middleware is resolving.
@@ -45,25 +41,35 @@ _**Note:** If using a React component for your error page, it can receive the er
 
 With strings:
 
-```jsx
-<GuardProvider loading="Loading..." error="Not found." />
+```tsx
+import { GuardProvider } from 'react-router-guards';
+
+<GuardProvider loading="Loading..." error="Not found." />;
 ```
 
 With React components:
 
-```jsx
-const NotFound = ({ error }) => (
+```tsx
+import {
+  ErrorPageComponentType,
+  GuardProvider,
+  LoadingPageComponentType,
+} from 'react-router-guards';
+
+const NotFound: ErrorPageComponentType = ({ error }) => (
   <div>
     <h1>Not found.</h1>
-    <p>{error}</p>
+    {error && <p>{error}</p>}
   </div>
 );
 
-const Loading = () => (
+const Loading: LoadingPageComponentType = () => (
   <div>
     <div id="loader" />
   </div>
 );
+
+// ...
 
 <GuardProvider loading={Loading} error={NotFound} />;
 ```

--- a/package.json
+++ b/package.json
@@ -47,10 +47,6 @@
     "*.{js,ts,tsx}": [
       "eslint --fix",
       "git add"
-    ],
-    "*.scss": [
-      "stylelint",
-      "git add"
     ]
   },
   "husky": {

--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -13,10 +13,10 @@ import {
   NextAction,
   NextPropsPayload,
   NextRedirectPayload,
+  RouteError,
 } from './types';
 
 type PageProps = NextPropsPayload;
-type RouteError = string | Record<string, any> | null;
 type RouteRedirect = NextRedirectPayload | null;
 
 interface GuardsResolve {

--- a/package/src/GuardedRoute.tsx
+++ b/package/src/GuardedRoute.tsx
@@ -5,7 +5,7 @@ import ContextWrapper from './ContextWrapper';
 import Guard from './Guard';
 import { ErrorPageContext, GuardContext, LoadingPageContext } from './contexts';
 import { useGlobalGuards } from './hooks';
-import { GuardedRouteProps, PageComponent, RouteError } from './types';
+import { GuardedRouteProps, LoadingPageComponent, ErrorPageComponent } from './types';
 
 const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
   children,
@@ -30,10 +30,8 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
       {...routeProps}
       render={() => (
         <GuardContext.Provider value={routeGuards}>
-          <ContextWrapper<PageComponent> context={LoadingPageContext} value={loading}>
-            <ContextWrapper<PageComponent<{ error: RouteError }>>
-              context={ErrorPageContext}
-              value={error}>
+          <ContextWrapper<LoadingPageComponent> context={LoadingPageContext} value={loading}>
+            <ContextWrapper<ErrorPageComponent> context={ErrorPageContext} value={error}>
               <Guard name={path} component={component} meta={meta} render={render}>
                 {children}
               </Guard>

--- a/package/src/GuardedRoute.tsx
+++ b/package/src/GuardedRoute.tsx
@@ -5,7 +5,7 @@ import ContextWrapper from './ContextWrapper';
 import Guard from './Guard';
 import { ErrorPageContext, GuardContext, LoadingPageContext } from './contexts';
 import { useGlobalGuards } from './hooks';
-import { GuardedRouteProps, PageComponent } from './types';
+import { GuardedRouteProps, PageComponent, RouteError } from './types';
 
 const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
   children,
@@ -31,7 +31,9 @@ const GuardedRoute: React.FunctionComponent<GuardedRouteProps> = ({
       render={() => (
         <GuardContext.Provider value={routeGuards}>
           <ContextWrapper<PageComponent> context={LoadingPageContext} value={loading}>
-            <ContextWrapper<PageComponent> context={ErrorPageContext} value={error}>
+            <ContextWrapper<PageComponent<{ error: RouteError }>>
+              context={ErrorPageContext}
+              value={error}>
               <Guard name={path} component={component} meta={meta} render={render}>
                 {children}
               </Guard>

--- a/package/src/contexts.ts
+++ b/package/src/contexts.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { PageComponent, GuardFunction } from './types';
+import { PageComponent, GuardFunction, RouteError } from './types';
 
-export const ErrorPageContext = createContext<PageComponent>(null);
+export const ErrorPageContext = createContext<PageComponent<{ error: RouteError }>>(null);
 
 export const FromRouteContext = createContext<RouteComponentProps | null>(null);
 

--- a/package/src/contexts.ts
+++ b/package/src/contexts.ts
@@ -1,11 +1,11 @@
 import { createContext } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { PageComponent, GuardFunction, RouteError } from './types';
+import { GuardFunction, ErrorPageComponent, LoadingPageComponent } from './types';
 
-export const ErrorPageContext = createContext<PageComponent<{ error: RouteError }>>(null);
+export const ErrorPageContext = createContext<ErrorPageComponent>(null);
 
 export const FromRouteContext = createContext<RouteComponentProps | null>(null);
 
 export const GuardContext = createContext<GuardFunction[] | null>(null);
 
-export const LoadingPageContext = createContext<PageComponent>(null);
+export const LoadingPageContext = createContext<LoadingPageComponent>(null);

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -7,4 +7,5 @@ export {
   GuardProviderProps,
   Next,
   PageComponent,
+  RouteError,
 } from './types';

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -6,6 +6,8 @@ export {
   GuardFunction,
   GuardProviderProps,
   Next,
-  PageComponent,
   RouteError,
+  PageComponent,
+  LoadingPageComponentType,
+  ErrorPageComponentType,
 } from './types';

--- a/package/src/renderPage.tsx
+++ b/package/src/renderPage.tsx
@@ -11,7 +11,7 @@ type BaseProps = Record<string, any>;
  * @returns the page component
  */
 function renderPage<Props extends BaseProps>(
-  page: PageComponent,
+  page: PageComponent<any>,
   props?: Props,
 ): React.ReactElement | null {
   if (!page) {

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -56,12 +56,26 @@ export type GuardFunction = (
   from: GuardFunctionRouteProps | null,
   next: Next,
 ) => void;
+
 export type RouteError = string | null;
 
 /**
  * Page Component Types
  */
-export type PageComponent<P = {}> = ComponentType<P> | null | undefined | string | boolean | number;
+export type PageComponentType<P = {}> = ComponentType<RouteComponentProps & P>;
+export type PageComponent<P = {}> =
+  | PageComponentType<P>
+  | null
+  | undefined
+  | string
+  | boolean
+  | number;
+
+export type LoadingPageComponent = PageComponent;
+export type ErrorPageComponent = PageComponent<{ error: RouteError }>;
+
+export type LoadingPageComponentType = PageComponentType;
+export type ErrorPageComponentType = PageComponentType<{ error: RouteError }>;
 
 /**
  * Props
@@ -69,8 +83,8 @@ export type PageComponent<P = {}> = ComponentType<P> | null | undefined | string
 export interface BaseGuardProps {
   guards?: GuardFunction[];
   ignoreGlobal?: boolean;
-  loading?: PageComponent;
-  error?: PageComponent<{ error: RouteError }>;
+  loading?: LoadingPageComponent;
+  error?: ErrorPageComponent;
 }
 
 export type PropsWithMeta<T> = T & {

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -56,11 +56,12 @@ export type GuardFunction = (
   from: GuardFunctionRouteProps | null,
   next: Next,
 ) => void;
+export type RouteError = string | null;
 
 /**
  * Page Component Types
  */
-export type PageComponent = ComponentType | null | undefined | string | boolean | number;
+export type PageComponent<P = {}> = ComponentType<P> | null | undefined | string | boolean | number;
 
 /**
  * Props
@@ -69,7 +70,7 @@ export interface BaseGuardProps {
   guards?: GuardFunction[];
   ignoreGlobal?: boolean;
   loading?: PageComponent;
-  error?: PageComponent;
+  error?: PageComponent<{ error: RouteError }>;
 }
 
 export type PropsWithMeta<T> = T & {


### PR DESCRIPTION
# Description

This fixes an issue with the `PageComponent` type not allowing for the `error` prop, that's used for error page components

## Related issues

Addresses #56 

## What this does

- Adds `RouteError` to export, removes `Record<string, any>` from `RouteError` type definition (this can only ever be a string or null)
- Adds new `LoadingPageComponentType` and `ErrorPageComponentType` types to describe the type of React _component_ expected (added to export)
- Updates usage of `PageComponent` to use specific `LoadingPageComponent` or `ErrorPageComponent` types
- Updates intermediate example with `NotFound` to use `error` prop
- Removes unused `stylelint` reference

## How to test

1. Pull down the repository and install (`npm i`, `npm run bootstrap`, `npm start`)
2. Visit the router config at `/demos/intermediate/src/router/index.tsx`
3. Confirm there is no error when passing the `NotFound` component into `error` prop
4. Visit the project http://localhost:3001
5. Visit a Missingno Pokémon. Confirm small error message appears under body text like so:

<img width="500" alt="Screen Shot 2021-09-13 at 1 41 20 PM" src="https://user-images.githubusercontent.com/17488657/133131166-017b48fa-5e00-40d9-8fc3-aefac54bbdc4.png">
