### PR TITLE
Resolve infinite redirects, broken redirects for same paths with different params

### DIFF
--- a/demos/intermediate/src/router/index.tsx
+++ b/demos/intermediate/src/router/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Router as BrowserRouter, Switch } from 'react-router-dom';
-import { GuardProvider, GuardedRoute } from 'react-router-guards';
+import { GuardProvider, GuardedRoute, GuardFunction } from 'react-router-guards';
 import { Detail, List, Loading, NotFound } from 'containers';
 import { beforeRouteEnter as detailBeforeEnter } from 'containers/Detail';
 import history from './history';
@@ -9,6 +9,15 @@ import { waitOneSecond } from './guards';
 interface Props {
   children(content: React.ReactElement): React.ReactElement;
 }
+
+const invalidName: GuardFunction = (to, from, next) => {
+  const { name } = to.match.params;
+  if (name === 'test') {
+    next.redirect('/test');
+  } else {
+    next();
+  }
+};
 
 const Router: React.FunctionComponent<Props> = ({ children }) => (
   <BrowserRouter history={history}>
@@ -20,7 +29,7 @@ const Router: React.FunctionComponent<Props> = ({ children }) => (
             path="/:name"
             exact
             component={Detail}
-            guards={[waitOneSecond, detailBeforeEnter]}
+            guards={[invalidName, waitOneSecond, detailBeforeEnter]}
           />
           <GuardedRoute path="*" component={NotFound} />
         </Switch>,

--- a/demos/intermediate/src/router/index.tsx
+++ b/demos/intermediate/src/router/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Router as BrowserRouter, Switch } from 'react-router-dom';
-import { GuardProvider, GuardedRoute, GuardFunction } from 'react-router-guards';
+import { GuardProvider, GuardedRoute } from 'react-router-guards';
 import { Detail, List, Loading, NotFound } from 'containers';
 import { beforeRouteEnter as detailBeforeEnter } from 'containers/Detail';
 import history from './history';
@@ -9,15 +9,6 @@ import { waitOneSecond } from './guards';
 interface Props {
   children(content: React.ReactElement): React.ReactElement;
 }
-
-const invalidName: GuardFunction = (to, from, next) => {
-  const { name } = to.match.params;
-  if (name === 'test') {
-    next.redirect('/test');
-  } else {
-    next();
-  }
-};
 
 const Router: React.FunctionComponent<Props> = ({ children }) => (
   <BrowserRouter history={history}>
@@ -29,7 +20,7 @@ const Router: React.FunctionComponent<Props> = ({ children }) => (
             path="/:name"
             exact
             component={Detail}
-            guards={[invalidName, waitOneSecond, detailBeforeEnter]}
+            guards={[waitOneSecond, detailBeforeEnter]}
           />
           <GuardedRoute path="*" component={NotFound} />
         </Switch>,

--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useMemo } from 'react';
 import { __RouterContext as RouterContext } from 'react-router';
-import { matchPath, Redirect, Route } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 import { ErrorPageContext, FromRouteContext, GuardContext, LoadingPageContext } from './contexts';
 import { usePrevious, useStateRef, useStateWhenMounted } from './hooks';
 import renderPage from './renderPage';
@@ -171,11 +171,11 @@ const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta,
   } else if (routeError) {
     return renderPage(ErrorPage, { ...routeProps, error: routeError });
   } else if (routeRedirect) {
-    const pathToMatch = typeof routeRedirect === 'string' ? routeRedirect : routeRedirect.pathname;
-    const { path, isExact: exact } = routeProps.match;
-    if (pathToMatch && !matchPath(pathToMatch, { path, exact })) {
-      return <Redirect to={routeRedirect} />;
+    const redirectPath = typeof routeRedirect === 'string' ? routeRedirect : routeRedirect.pathname;
+    if (redirectPath === routeProps.location.pathname) {
+      return renderPage(ErrorPage, { ...routeProps, error: 'Infinite redirect.' });
     }
+    return <Redirect to={routeRedirect} />;
   }
   return (
     <RouterContext.Provider value={{ ...routeProps, ...pageProps }}>

--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -139,11 +139,11 @@ const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta,
         const redirectPath =
           typeof routeRedirect === 'string' ? routeRedirect : routeRedirect.pathname;
         if (redirectPath === routeProps.location.pathname) {
-          throw new Error('Infinite redirect.');
+          throw new Error('rrg/infinite-redirect');
         }
       }
     } catch (error) {
-      routeError = error.message || 'Not found.';
+      routeError = error.message || 'rrg/error';
     }
 
     if (currentRequests === getValidationsRequested()) {

--- a/package/src/Guard.tsx
+++ b/package/src/Guard.tsx
@@ -133,6 +133,15 @@ const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta,
       const { props, redirect } = await resolveAllGuards();
       pageProps = props;
       routeRedirect = redirect;
+
+      // If there's a redirect, determine if it'll be infinite and throw error if so
+      if (routeRedirect) {
+        const redirectPath =
+          typeof routeRedirect === 'string' ? routeRedirect : routeRedirect.pathname;
+        if (redirectPath === routeProps.location.pathname) {
+          throw new Error('Infinite redirect.');
+        }
+      }
     } catch (error) {
       routeError = error.message || 'Not found.';
     }
@@ -171,10 +180,6 @@ const Guard: React.FunctionComponent<GuardProps> = ({ children, component, meta,
   } else if (routeError) {
     return renderPage(ErrorPage, { ...routeProps, error: routeError });
   } else if (routeRedirect) {
-    const redirectPath = typeof routeRedirect === 'string' ? routeRedirect : routeRedirect.pathname;
-    if (redirectPath === routeProps.location.pathname) {
-      return renderPage(ErrorPage, { ...routeProps, error: 'Infinite redirect.' });
-    }
     return <Redirect to={routeRedirect} />;
   }
   return (


### PR DESCRIPTION
# Description

In our render resolution of `Guard`, we included a method to resolve redirecting to the same path.

Unfortunately, this didn't actually account for a redirect to the same path with different parameters. To fix this, we now perform a check for infinite redirection and _only_ perform redirects in the render

## Related issues

Fixes #55 

## What this does

- Adds a check for infinite renders in `validateRoute` and throws up an error if so
- Removes path checking in `routeRedirect` case of render—now only renders the `Redirect` component
- Update default error from `'Not found.'` to `rrg/error` (to match other errors)

## How to test

Following the example in #55:

1. Pull down the repo locally and set up the dev server (`npm i`, `npm run bootstrap`, `npm start`)

2. In `src/router/index.tsx`, add the following guard function:

```tsx
const invalidName: GuardFunction = (to, from, next) => {
  const { name } = to.match.params;
  if (name === 'test') {
    next.redirect('/charmander');
  } else {
    next();
  }
};
```
```diff
  <GuardedRoute
    path="/:name"
    exact
    component={Detail}
-   guards={[waitOneSecond, detailBeforeEnter]}
+   guards={[invalidName, waitOneSecond, detailBeforeEnter]}
  />
```

3. Visit http://localhost:3001/test. Confirm the redirect resolves correctly to `/charmander`
4. Update the `invalidName` guard to cause an infinite redirect to `/test`
5. Confirm the app doesn't infinitely redirect + break, but rather throws up an error page

## Additional Notes

Currently the routes are only "matched" by their pathname—something that will be changed by #39 (or similar functionality changes from that)
