### PR TITLE
Ignore Netlify builds for dependabot PRs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "git log -1 --pretty=%B | grep dependabot"
   base = "."
   publish = "demos/intermediate/dist"
   command = "npm run bootstrap && npm run build:demo"


### PR DESCRIPTION
# Description

Ignore Netlify builds for dependabot PRs

## What this does

- Adds an `ignore` config like listed here: https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/
